### PR TITLE
switch_to.frame_by_element()

### DIFF
--- a/pylenium/switch_to.py
+++ b/pylenium/switch_to.py
@@ -1,5 +1,5 @@
-from selenium.common.exceptions import NoSuchFrameException
 from selenium.webdriver.support import expected_conditions as ec
+from pylenium.element import Element
 
 
 class SwitchTo:
@@ -7,7 +7,7 @@ class SwitchTo:
         self._py = pylenium
 
     def frame(self, name_or_id: str, timeout: int = 0):
-        """ Switch the driver's context to the new frame.
+        """ Switch the driver's context to the new frame given the name or id of the element.
 
         Args:
             name_or_id: The frame's `id` or `name` attribute value
@@ -21,6 +21,21 @@ class SwitchTo:
         self._py.wait(timeout).until(ec.frame_to_be_available_and_switch_to_it(name_or_id))
         return self._py
 
+    def frame_by_element(self, element: Element, timeout: int = 0):
+        """ Switch the driver's context to the given frame element.
+
+        Args:
+            element (Element): The frame element to switch to
+            timeout: The number of seconds to wait for the frame to be switched to.
+
+        Examples:
+            iframe = py.get('iframe')
+            py.switch_to.frame_by_element(iframe)
+        """
+        self._py.log.info('[STEP] py.switch_to.frame_by_element() - Switch to frame using an Element.')
+        self._py.wait(timeout).until(ec.frame_to_be_available_and_switch_to_it(element.locator))
+        return self._py
+
     def parent_frame(self):
         """ Switch the driver's context to the parent frame.
 
@@ -32,7 +47,7 @@ class SwitchTo:
 
     def default_content(self):
         """ Switch the driver's context to the default content. """
-        self._py.log.info('[STEP] py.switch_to.default_content() - Switch to the default content of this browser session')
+        self._py.log.info('[STEP] py.switch_to.default_content() - Switch to default content of this browser session')
         self._py.webdriver.switch_to.default_content()
         return self._py
 
@@ -59,7 +74,8 @@ class SwitchTo:
             self._py.webdriver.switch_to.window(handle)
             return self._py
         elif name_or_handle:
-            self._py.log.info(f'[STEP] py.switch_to.window() - Switch to a Tab or Window by name or handle: ``{name_or_handle}``')
+            self._py.log.info(
+                f'[STEP] py.switch_to.window() - Switch to Tab or Window by name or handle: ``{name_or_handle}``')
             self._py.webdriver.switch_to.window(name_or_handle)
             return self._py
         else:

--- a/tests/ui/test_pydriver.py
+++ b/tests/ui/test_pydriver.py
@@ -1,4 +1,3 @@
-import pytest
 from selenium.webdriver.common.keys import Keys
 
 
@@ -97,6 +96,15 @@ def test_switch_to_frame_then_back(py):
     py.switch_to.frame('mce_0_ifr').get('#tinymce').type('bar')
     assert py.get('#tinymce').text() == 'foobar'
     assert py.switch_to.parent_frame().contains('An iFrame').tag_name() == 'h3'
+
+
+def test_switch_to_frame_by_element(py):
+    py.visit('http://the-internet.herokuapp.com/iframe')
+    iframe = py.get('#mce_0_ifr')
+    py.switch_to.frame_by_element(iframe).get('#tinymce').clear().type('foo')
+    assert py.switch_to.default_content().contains('An iFrame').tag_name() == 'h3'
+    py.switch_to.frame_by_element(iframe).get('#tinymce').type('bar')
+    assert py.get('#tinymce').text() == 'foobar'
 
 
 def test_have_url(py):


### PR DESCRIPTION
## Description

Some of our users have to deal with iframes that _do not_ have a `name` or `id` attribute, so they couldn't use the `py.switch_to.frame(str)` command. They would have to go about it a roundabout way that just didn't feel very clean.

We've now added a `.frame_by_element()` command!

## Added

* `py.switch_to.frame_by_element(element, timeout)`

Now you can switch to an iframe by passing in an `Element` object!

## Examples

```python
iframe = py.get('iframe')
py.switch_to.frame_by_element(iframe)
```

## Linked Issues
* #139 
* GitKraken Card: [py.switch_to.frame() should also allow an Element instead of name_or_id](https://app.gitkraken.com/glo/view/card/6c15999d151c42239b30d9bcaf5471ea)