### PR TITLE
Add get_list_of_packages function to setup.py

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -6,6 +6,7 @@ verify_ssl = true
 [dev-packages]
 flake8 = "*"
 autopep8 = "*"
+toml = "*"
 
 [packages]
 # webdriver

--- a/pylenium/scripts/setup_tools.py
+++ b/pylenium/scripts/setup_tools.py
@@ -1,0 +1,9 @@
+import toml
+
+
+def get_install_requirements(file) -> list:
+    """ Parses a pipfile and returns a list of package names along with a version if applicable """
+    pipfile = toml.load(file)
+    packages = pipfile.get('packages').items()
+    return ["{0}{1}".format(pkg, ver) if ver != "*"
+            else pkg for pkg, ver in packages]

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,19 @@
 from setuptools import setup, find_packages
 import pylenium as app
+import subprocess
+import json
+
+
+def get_list_of_packages() -> list:
+    """ Get a list of current dependencies from pip via the cmd line """
+    output = subprocess.getoutput("pip list --not-required --format=json")
+    packages = []
+    not_needed = ['setuptools', 'pip']
+    for item in json.loads(output.split('\n')[0]):
+        if item['name'] not in not_needed:
+            packages.append(item['name'])
+
+    return packages
 
 
 setup(
@@ -14,10 +28,7 @@ setup(
     description='The best of Selenium and Cypress in a single Python Package',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
-    install_requires=[
-        'selenium', 'pytest', 'pytest-xdist', 'pytest-parallel', 'pydantic', 'pytest-reportportal',
-        'faker', 'requests', 'webdriver-manager', 'click', 'pyfiglet', 'axe-selenium-python'
-    ],
+    install_requires=get_list_of_packages(),
     data_files=[('', [
         'pylenium/scripts/pylenium.json',
         'pylenium/scripts/pytest.ini',

--- a/setup.py
+++ b/setup.py
@@ -1,14 +1,6 @@
 from setuptools import setup, find_packages
+from pylenium.scripts.setup_tools import get_install_requirements
 import pylenium as app
-import toml
-
-
-def get_install_requirements() -> list:
-    """ Parses a pipfile and returns a list of package names along with a version if applicable """
-    pipfile = toml.load('Pipfile')
-    packages = pipfile.get('packages').items()
-    return ["{0}{1}".format(pkg, ver) if ver != "*"
-            else pkg for pkg, ver in packages]
 
 
 setup(
@@ -23,7 +15,7 @@ setup(
     description='The best of Selenium and Cypress in a single Python Package',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
-    install_requires=get_install_requirements(),
+    install_requires=get_install_requirements('Pipfile'),
     data_files=[('', [
         'pylenium/scripts/pylenium.json',
         'pylenium/scripts/pytest.ini',

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,14 @@
 from setuptools import setup, find_packages
 import pylenium as app
-import subprocess
-import json
+import toml
 
 
-def get_list_of_packages() -> list:
-    """ Get a list of current dependencies from pip via the cmd line """
-    output = subprocess.getoutput("pip list --not-required --format=json")
-    packages = []
-    not_needed = ['setuptools', 'pip']
-    for item in json.loads(output.split('\n')[0]):
-        if item['name'] not in not_needed:
-            packages.append(item['name'])
-
-    return packages
+def get_install_requirements() -> list:
+    """ Parses a pipfile and returns a list of package names along with a version if applicable """
+    pipfile = toml.load('Pipfile')
+    packages = pipfile.get('packages').items()
+    return ["{0}{1}".format(pkg, ver) if ver != "*"
+            else pkg for pkg, ver in packages]
 
 
 setup(
@@ -28,7 +23,7 @@ setup(
     description='The best of Selenium and Cypress in a single Python Package',
     long_description=open('README.md').read(),
     long_description_content_type='text/markdown',
-    install_requires=get_list_of_packages(),
+    install_requires=get_install_requirements(),
     data_files=[('', [
         'pylenium/scripts/pylenium.json',
         'pylenium/scripts/pytest.ini',

--- a/tests/unit/test_setup_tools.py
+++ b/tests/unit/test_setup_tools.py
@@ -1,0 +1,6 @@
+from pylenium.scripts.setup_tools import get_install_requirements
+
+
+def test_get_install_requirements_returns_list(project_root):
+    result = get_install_requirements(f'{project_root}/Pipfile')
+    assert isinstance(result, list) and 'selenium' in result


### PR DESCRIPTION
### Issue
resolve #142 

### Description of the Change

As I was doing some research I found these docs [pip list](https://pip.pypa.io/en/stable/reference/pip_list/).  With some playing I found this command `$ pip list --not-required --format=json`.

My goal is to have a function that would find what packages are currently listed and return an array of those packages.  You could call this function in the `install_requires=` section of the `setup.py` file.

### Alternate Designs

I also read about `requirements.txt` vs `setup.py`, but it seems as if `requirements.txt` was more strict on versions.

### Possible Drawbacks

I don't fully understand the `setup.py` process and how it works for users that are doing `$ pipenv install pyleniumio` so this could be wrong.

When I forked/cloned the repo I did the command `$ pip list --not-required --format=json` before `$ pipenv sync` or `$ pipenv lock` and it didn't list all of the packages.  My function really only works when all packages have been installed in that environment.

Also please see my original comment in the #142 for a possible error with `$ pip list --not-required --format=json` sometimes returning too much data.

### Verification Process

I did a manual test locally in a separate project by running my function in its own file.  I also did a manual test in the pyleniumio project by adding my function to the `setup.py` along with a `print(get_list_of_packages())`.  I commented out all of the setup process to see what packages it would find by manually running the file in the cmd line with `$ python setup.py`.

- With the following cmd `$ pip list --format=json` it returns the following list with a length of 37 items:
```
['apipkg', 'attrs', 'axe-selenium-python', 'certifi', 'chardet', 'click', 'colorama', 'configparser', 'crayons', 'delayed-assert', 'dill', 'execnet', 'Faker', 'idna', 'iniconfig', 'more-itertools', 'packaging', 'pluggy', 'py', 'pydantic', 'pyfiglet', 'pyparsing', 'pytest', 'pytest-forked', 'pytest-parallel', 'pytest-reportportal', 'pytest-xdist', 'python-dateutil', 'reportportal-client', 'requests', 'selenium', 'six', 'tblib', 'text-unidecode', 'toml', 'urllib3', 'webdriver-manager']
```

- With the following cmd `$ pip list --format=json` it returns the following list with a length of 10 items:
```
['axe-selenium-python', 'click', 'Faker', 'pydantic', 'pyfiglet', 'pytest-parallel', 'pytest-reportportal', 'pytest-xdist', 'webdriver-manager']
```

### Release Notes

Added a `get_list_of_packages` function to the `setup.py` file for automation of new packages between the `pipfile` and `setup.py` file.
