### PR TITLE
use originalname instead of .name

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -109,7 +109,7 @@ def test_run(project_root, request) -> str:
 
     for test in session.items:
         # make the test_result directory for each test
-        make_dir(f'{test_results_dir}/{test.name}')
+        make_dir(f'{test_results_dir}/{test.originalname}')
 
     return test_results_dir
 


### PR DESCRIPTION
when generating results for the test right now, it creates it in this structure of
test_results/[test_name][param]

with this change it will generate the folder structure of 
test_results[test_name]

this drops off things at the end like [py0] when using parameters