### PR TITLE
add Selenium's Keys reference to Pylenium class

### DIFF
--- a/docs/element-commands/type.md
+++ b/docs/element-commands/type.md
@@ -18,8 +18,7 @@ py.get('#username').type('my-username')
 
 ---or--- # combine with other keys and strings
 
-# import the Keys from selenium
-py.get('#search').type('puppies', Keys.ENTER)
+py.get('#search').type('puppies', py.Keys.ENTER)
 
 ---or--- # chain an Element command
 
@@ -39,7 +38,7 @@ py.get('a').type('foo')
 * `*args (Any)` - A comma-separated list of arguments to type
 
 {% hint style="success" %}
-It's best to use **strings** and the **Keys** from Selenium
+It's best to use **strings** and the **Keys** class
 {% endhint %}
 
 ## Yields

--- a/docs/examples/test_sample.py
+++ b/docs/examples/test_sample.py
@@ -11,7 +11,6 @@ on Twitter or LinkedIn.
 
 # You can mix Selenium into some Pylenium commands
 from selenium.webdriver.common.by import By
-from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as ec
 
 
@@ -21,7 +20,7 @@ def test_pylenium_basics(py):
     # Use Cypress-like commands like `.visit()`
     py.visit('https://google.com')
     # `.get()` uses CSS to locate a single element
-    py.get('[name="q"]').type('puppies', Keys.ENTER)
+    py.get('[name="q"]').type('puppies', py.Keys.ENTER)
     # `assert` followed by a boolean expression
     assert 'puppies' in py.title
 
@@ -34,12 +33,12 @@ def test_access_selenium(py):
     assert py.get('[name"q"]').webelement.is_enabled()
     # you can store elements and objects to be used later since
     # we don't rely on Promises or chaining in Python
-    search_field.send_keys('puppies', Keys.ENTER)
+    search_field.send_keys('puppies', py.Keys.ENTER)
     assert 'puppies' in py.title
 
 
 def test_chaining_commands(py):
-    py.visit('https://google.com').get('[name="q"]').type('puppies', Keys.ENTER)
+    py.visit('https://google.com').get('[name="q"]').type('puppies', py.Keys.ENTER)
     assert 'puppies' in py.title
 
 
@@ -49,6 +48,6 @@ def test_waiting(py):
     # default `.wait()` uses WebDriverWait which returns Selenium's WebElement objects
     py.wait().until(ec.visibility_of_element_located((By.CSS_SELECTOR, '[name="q"]'))).send_keys('puppies')
     # use_py=True to use a PyleniumWait which returns Pylenium's Element and Elements objects
-    py.wait(use_py=True).until(lambda _: py.get('[name="q"]')).type(Keys.ENTER)
+    py.wait(use_py=True).until(lambda _: py.get('[name="q"]')).type(py.Keys.ENTER)
     # wait using lambda function
     assert py.wait().until(lambda x: 'puppies' in x.title)

--- a/pylenium/driver.py
+++ b/pylenium/driver.py
@@ -4,6 +4,7 @@ from typing import List, Union
 import requests
 from faker import Faker
 from selenium.common.exceptions import TimeoutException, WebDriverException
+from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.common.by import By
 from selenium.webdriver.remote.webdriver import WebDriver
 from selenium.webdriver.support.wait import WebDriverWait
@@ -192,6 +193,7 @@ class Pylenium:
         self.log = logging.getLogger(__name__)
         self.fake = Faker()
         self.request = requests
+        self.Keys = Keys
         self._webdriver = None
         self._wait = None
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,6 @@ license = "MIT"
 
 [tool.poetry.dependencies]
 python = "^3.8"
-selenium = "^3.141.0"
 webdriver-manager = "^3.3.0"
 pydantic = "^1.7.3"
 Faker = "^5.8.0"
@@ -19,6 +18,7 @@ pytest-reportportal = "^5.0.7"
 pytest-xdist = "^2.2.0"
 pytest-parallel = "^0.1.0"
 axe-selenium-python = "^2.1.6"
+selenium = "^3.141.0"
 
 [tool.poetry.dev-dependencies]
 flake8 = "^3.8.4"

--- a/tests/ui/test_pydriver.py
+++ b/tests/ui/test_pydriver.py
@@ -1,5 +1,4 @@
 import os
-from selenium.webdriver.common.keys import Keys
 from pylenium.a11y import PyleniumAxe
 from pylenium.driver import Pylenium
 
@@ -24,7 +23,7 @@ def test_execute_script(py: Pylenium):
 
 def test_google_search(py: Pylenium):
     py.visit('https://google.com')
-    py.get("[name='q']").type('puppies', Keys.ENTER)
+    py.get("[name='q']").type('puppies', py.Keys.ENTER)
     assert py.should().contain_title('puppies')
 
 
@@ -55,7 +54,7 @@ def test_viewport(py: Pylenium):
 
 def test_get_xpath(py: Pylenium):
     py.visit('https://google.com')
-    py.getx('//*[@name="q"]').type('QA at the Point', Keys.ENTER)
+    py.getx('//*[@name="q"]').type('QA at the Point', py.Keys.ENTER)
     assert py.should().contain_title('QA at the Point')
 
 


### PR DESCRIPTION
Resolves #188 

**Before**
```python
from selenium.webdriver.common.keys import Keys

py.get('#input').type('puppies', Keys.ENTER)
```

**Now `Keys` is part of the Pylenium class so it's much easier to access**
```python
py.get('#input').type('puppies', py.Keys.ENTER)
```