### PR TITLE
Update Selenium example so it works just by copy/paste

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,12 @@ def test_carlos_is_on_leadership(py):
 ```
 
 ```python
+from selenium import webdriver
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.wait import WebDriverWait
+
 # define your setup and teardown fixture
 @pytest.fixture
 def driver():
@@ -37,18 +43,18 @@ def driver():
     driver.quit()
 
 
-def test_carlos_is_on_leadership_page_with_selenium(driver_setup):
+def test_carlos_is_on_leadership_page_with_selenium(driver):
     wait = WebDriverWait(driver, timeout=10)
     driver.get('https://qap.dev')
-    
+
     # hover About link
     about_link = driver.find_element(By.CSS_SELECTOR, "a[href='/about']")
     actions = ActionChains(driver)
     actions.move_to_element(about_link).perform()
-    
+
     # click Leadership link in About menu
-    wait.until(EC.element_visible(By.CSS_SELECTOR, "a[href='/leadership'][class^='Header-nav']")).click()
-    
+    wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, "a[href='/leadership'][class^='Header-nav']"))).click()
+
     # check if 'Carlos Kidman' is on the page
     assert wait.until(lambda _: driver.find_element(By.XPATH, "//*[contains(text(), 'Carlos Kidman')]"))
 ```
@@ -116,4 +122,3 @@ python -m pytest tests/test_google.py
 ```
 
 You're all set! You should see the browser open and complete the commands we had in the test :\)
-

--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,12 @@ def test_carlos_is_on_leadership(py):
 
 {% code title="The same test using Selenium" %}
 ```python
+from selenium import webdriver
+from selenium.webdriver.common.action_chains import ActionChains
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support import expected_conditions as EC
+from selenium.webdriver.support.wait import WebDriverWait
+
 # define your setup and teardown fixture
 @pytest.fixture
 def driver():
@@ -50,7 +56,7 @@ def driver():
     driver.quit()
 
 
-def test_carlos_is_on_leadership_page_with_selenium(driver_setup):
+def test_carlos_is_on_leadership_page_with_selenium(driver):
     wait = WebDriverWait(driver, timeout=10)
     driver.get('https://qap.dev')
 
@@ -60,7 +66,7 @@ def test_carlos_is_on_leadership_page_with_selenium(driver_setup):
     actions.move_to_element(about_link).perform()
 
     # click Leadership link in About menu
-    wait.until(EC.element_visible(By.CSS_SELECTOR, "a[href='/leadership'][class^='Header-nav']")).click()
+    wait.until(EC.visibility_of_element_located((By.CSS_SELECTOR, "a[href='/leadership'][class^='Header-nav']"))).click()
 
     # check if 'Carlos Kidman' is on the page
     assert wait.until(lambda _: driver.find_element(By.XPATH, "//*[contains(text(), 'Carlos Kidman')]"))
@@ -170,4 +176,3 @@ python -m pytest tests/test_google.py
 {% endcode %}
 
 You're all set! You should see the browser open and complete the commands we had in the test :\)
-

--- a/docs/configuration/pylenium.json.md
+++ b/docs/configuration/pylenium.json.md
@@ -24,7 +24,7 @@ Here are all of the current settings \(and their defaults\) you can configure ri
     "version": "latest"
   },
 
-  "logging":{
+  "logging": {
     "screenshots_on": true,
     "pylog_level": "info"
   },
@@ -35,7 +35,7 @@ Here are all of the current settings \(and their defaults\) you can configure ri
     "height": 900,
     "orientation": "portrait"
   },
-  
+
   "custom": {}
 }
 ```
@@ -111,4 +111,3 @@ py.config.custom['environment']['url']
 # Get the first item in the list of clusters
 py.config.custom['environment']['clusters'][0]
 ```
-

--- a/pylenium.json
+++ b/pylenium.json
@@ -12,7 +12,7 @@
     "local_path": ""
   },
 
-  "logging":{
+  "logging": {
     "screenshots_on": true,
     "pylog_level": "info"
   },

--- a/pylenium/scripts/pylenium.json
+++ b/pylenium/scripts/pylenium.json
@@ -12,7 +12,7 @@
     "local_path": ""
   },
 
-  "logging":{
+  "logging": {
     "screenshots_on": true,
     "pylog_level": "info"
   },


### PR DESCRIPTION
I've tried the sample Selenium code on the README and found it doesn't work as it's currently given, so I've decided to fix it up a bit.  I've included the `import` statements to further help show how much more verbose vanilla Selenium is, but can take it out if you wish.  You can now simply copy and paste the code and it should work.

This was tested with Python 3.6.8, Selenium 3.141.0, and Chrome 90.0.4430.

Also, added a missing space in the `json`.