### PR TITLE
Feat: pass arbitrary kwargs to webdrivers

### DIFF
--- a/docs/configuration/driver.md
+++ b/docs/configuration/driver.md
@@ -27,6 +27,7 @@ Supported Drivers:
     "experimental_options": null,
     "capabilities": {},
     "extension_paths": [],
+    "webdriver_kwargs": {},
     "version": "latest"
   }
 ```
@@ -210,6 +211,22 @@ Default is empty or `[]`
 {
     "driver": {
         "extension_paths": ["path_to_crx.crx", "other-path.crx"]
+    }
+}
+```
+
+### webdriver_kwargs
+
+Arbitrary keyword arguments to pass to the Selenium webdriver.
+
+{% hint style="info" %}
+Default is empty or `{}`
+{% endhint %}
+
+```javascript
+{
+    "driver": {
+        "webdriver_kwargs": {"service_log_path": "webdriver.log"}
     }
 }
 ```

--- a/docs/configuration/pylenium.json.md
+++ b/docs/configuration/pylenium.json.md
@@ -21,6 +21,7 @@ Here are all of the current settings \(and their defaults\) you can configure ri
     "experimental_options": null,
     "capabilities": {},
     "extension_paths": [],
+    "webdriver_kwargs": {},
     "version": "latest"
   },
 

--- a/pylenium.json
+++ b/pylenium.json
@@ -9,6 +9,7 @@
     "version": "latest",
     "experimental_options": null,
     "extension_paths": [],
+    "webdriver_kwargs": {},
     "local_path": ""
   },
   "logging": {

--- a/pylenium/config.py
+++ b/pylenium/config.py
@@ -15,6 +15,7 @@ class DriverConfig(BaseModel):
     capabilities: dict = {}
     experimental_options: List[dict] = None
     extension_paths: List[str] = None
+    webdriver_kwargs: dict = None
     version: str = 'latest'
     local_path: str = ''
 

--- a/pylenium/scripts/pylenium.json
+++ b/pylenium/scripts/pylenium.json
@@ -9,6 +9,7 @@
     "version": "latest",
     "experimental_options": null,
     "extension_paths": [],
+    "webdriver_kwargs": {},
     "local_path": ""
   },
   "logging": {

--- a/pylenium/webdriver_factory.py
+++ b/pylenium/webdriver_factory.py
@@ -111,7 +111,8 @@ def build_from_config(config: PyleniumConfig) -> WebDriver:
             browser_options=config.driver.options,
             capabilities=config.driver.capabilities,
             experimental_options=config.driver.experimental_options,
-            extension_paths=config.driver.extension_paths
+            extension_paths=config.driver.extension_paths,
+            webdriver_kwargs=config.driver.webdriver_kwargs
         )
     browser = config.driver.browser.lower()
     if browser == Browser.CHROME:
@@ -120,7 +121,8 @@ def build_from_config(config: PyleniumConfig) -> WebDriver:
             config.driver.options,
             config.driver.experimental_options,
             config.driver.extension_paths,
-            config.driver.local_path)
+            config.driver.local_path,
+            config.driver.webdriver_kwargs)
     elif browser == Browser.FIREFOX:
         return build_firefox(
             config.driver.version,
@@ -128,7 +130,8 @@ def build_from_config(config: PyleniumConfig) -> WebDriver:
             config.driver.capabilities,
             config.driver.experimental_options,
             config.driver.extension_paths,
-            config.driver.local_path)
+            config.driver.local_path,
+            config.driver.webdriver_kwargs)
     elif browser == Browser.IE:
         return build_ie(
             config.driver.version,
@@ -136,14 +139,16 @@ def build_from_config(config: PyleniumConfig) -> WebDriver:
             config.driver.capabilities,
             config.driver.experimental_options,
             config.driver.extension_paths,
-            config.driver.local_path)
+            config.driver.local_path,
+            config.driver.webdriver_kwargs)
     elif browser == Browser.OPERA:
         return build_opera(
             config.driver.version,
             config.driver.options,
             config.driver.experimental_options,
             config.driver.extension_paths,
-            config.driver.local_path)
+            config.driver.local_path,
+            config.driver.webdriver_kwargs)
     elif browser == Browser.EDGE:
         return build_edge(
             config.driver.version,
@@ -151,7 +156,8 @@ def build_from_config(config: PyleniumConfig) -> WebDriver:
             config.driver.capabilities,
             config.driver.experimental_options,
             config.driver.extension_paths,
-            config.driver.local_path)
+            config.driver.local_path,
+            config.driver.webdriver_kwargs)
     else:
         raise ValueError(f'{config.driver.browser} is not supported. https://elsnoman.gitbook.io/pylenium/configuration/driver')
 
@@ -160,7 +166,8 @@ def build_chrome(version: str,
                  browser_options: List[str],
                  experimental_options: Optional[List[dict]],
                  extension_paths: Optional[List[str]],
-                 local_path: Optional[str]) -> WebDriver:
+                 local_path: Optional[str],
+                 webdriver_kwargs: Optional[dict]) -> WebDriver:
     """ Build a ChromeDriver.
 
     Args:
@@ -169,14 +176,15 @@ def build_chrome(version: str,
         experimental_options: The list of experimental options to include.
         extension_paths: The list of extensions to add to the browser.
         local_path: The path to the driver binary.
+        webdriver_kwargs: additional keyword arguments to pass.
 
     Examples:
         driver = WebDriverFactory().build_chrome('latest', ['headless', 'incognito'], None)
     """
     options = build_options(Browser.CHROME, browser_options, experimental_options, extension_paths)
     if local_path:
-        return webdriver.Chrome(local_path, options=options)
-    return webdriver.Chrome(ChromeDriverManager(version=version).install(), options=options)
+        return webdriver.Chrome(local_path, options=options, **(webdriver_kwargs or {}))
+    return webdriver.Chrome(ChromeDriverManager(version=version).install(), options=options, **(webdriver_kwargs or {}))
 
 
 def build_edge(version: str,
@@ -184,7 +192,8 @@ def build_edge(version: str,
                capabilities: dict,
                experimental_options: Optional[List[dict]],
                extension_paths: Optional[List[str]],
-               local_path: Optional[str]) -> WebDriver:
+               local_path: Optional[str],
+               webdriver_kwargs: Optional[dict]) -> WebDriver:
     """ Build a Edge Driver.
 
     Args:
@@ -194,14 +203,15 @@ def build_edge(version: str,
         experimental_options: The list of experimental options to include.
         extension_paths: The list of extensions to add to the browser.
         local_path: The path to the driver binary.
+        webdriver_kwargs: additional keyword arguments to pass.
 
     Examples:
         driver = WebDriverFactory().build_edge('latest', ['headless', 'incognito'], None)
     """
     caps = build_capabilities(Browser.EDGE, capabilities)
     if local_path:
-        return webdriver.Edge(local_path, capabilities=caps)
-    return webdriver.Edge(EdgeChromiumDriverManager(version=version).install(),  capabilities=caps)
+        return webdriver.Edge(local_path, capabilities=caps, **(webdriver_kwargs or {}))
+    return webdriver.Edge(EdgeChromiumDriverManager(version=version).install(),  capabilities=caps, **(webdriver_kwargs or {}))
 
 
 def build_firefox(version: str,
@@ -209,7 +219,8 @@ def build_firefox(version: str,
                   capabilities: dict,
                   experimental_options: Optional[List[dict]],
                   extension_paths: Optional[List[str]],
-                  local_path: Optional[str]) -> WebDriver:
+                  local_path: Optional[str],
+                  webdriver_kwargs: Optional[dict]) -> WebDriver:
     """ Build a FirefoxDriver.
 
     Args:
@@ -219,6 +230,7 @@ def build_firefox(version: str,
         experimental_options: The list of experimental options to include.
         extension_paths: The list of extensions to add to the browser.
         local_path: The path to the driver binary.
+        webdriver_kwargs: additional keyword arguments to pass.
 
     Examples:
         driver = WebDriverFactory().build_firefox('latest', ['headless', 'incognito'], None)
@@ -226,8 +238,8 @@ def build_firefox(version: str,
     caps = build_capabilities(Browser.FIREFOX, capabilities)
     options = build_options(Browser.FIREFOX, browser_options, experimental_options, extension_paths)
     if local_path:
-        return webdriver.Firefox(executable_path=local_path, options=options, capabilities=caps)
-    return webdriver.Firefox(executable_path=GeckoDriverManager(version=version).install(), options=options)
+        return webdriver.Firefox(executable_path=local_path, options=options, capabilities=caps, **(webdriver_kwargs or {}))
+    return webdriver.Firefox(executable_path=GeckoDriverManager(version=version).install(), options=options, **(webdriver_kwargs or {}))
 
 
 def build_ie(version: str,
@@ -235,7 +247,8 @@ def build_ie(version: str,
              capabilities: dict,
              experimental_options: Optional[List[dict]],
              extension_paths: Optional[List[str]],
-             local_path: Optional[str]) -> WebDriver:
+             local_path: Optional[str],
+             webdriver_kwargs: Optional[dict]) -> WebDriver:
     """ Build an IEDriver.
 
     Args:
@@ -245,6 +258,7 @@ def build_ie(version: str,
         experimental_options: The list of experimental options to include.
         extension_paths: The list of extensions to add to the browser.
         local_path: The path to the driver binary.
+        webdriver_kwargs: additional keyword arguments to pass.
 
     Examples:
         driver = WebDriverFactory().build_ie('latest', ['headless'], None)
@@ -252,15 +266,16 @@ def build_ie(version: str,
     caps = build_capabilities(Browser.IE, capabilities)
     options = build_options(Browser.IE, browser_options, experimental_options, extension_paths)
     if local_path:
-        return webdriver.Ie(executable_path=local_path, options=options, capabilities=caps)
-    return webdriver.Ie(executable_path=IEDriverManager(version=version).install(), options=options, capabilities=caps)
+        return webdriver.Ie(executable_path=local_path, options=options, capabilities=caps, **(webdriver_kwargs or {}))
+    return webdriver.Ie(executable_path=IEDriverManager(version=version).install(), options=options, capabilities=caps, **(webdriver_kwargs or {}))
 
 
 def build_opera(version: str,
                 browser_options: List[str],
                 experimental_options: Optional[List[dict]],
                 extension_paths: Optional[List[str]],
-                local_path: Optional[str]) -> WebDriver:
+                local_path: Optional[str],
+                webdriver_kwargs: Optional[dict]) -> WebDriver:
     """ Build an OperaDriver.
 
     Args:
@@ -269,14 +284,15 @@ def build_opera(version: str,
         experimental_options: The list of experimental options to include.
         extension_paths: The list of extensions to add to the browser.
         local_path: The path to the driver binary.
+        webdriver_kwargs: additional keyword arguments to pass.
 
     Examples:
         driver = WebDriverFactory().build_opera('latest', ['--start-maximized'], None)
     """
     options = build_options(Browser.OPERA, browser_options, experimental_options, extension_paths)
     if local_path:
-        return webdriver.Opera(executable_path=local_path, options=options)
-    return webdriver.Opera(executable_path=OperaDriverManager(version=version).install(), options=options)
+        return webdriver.Opera(executable_path=local_path, options=options, **(webdriver_kwargs or {}))
+    return webdriver.Opera(executable_path=OperaDriverManager(version=version).install(), options=options, **(webdriver_kwargs or {}))
 
 
 def build_remote(browser: str,
@@ -284,7 +300,8 @@ def build_remote(browser: str,
                  browser_options: List[str],
                  capabilities: dict,
                  experimental_options: Optional[List[dict]],
-                 extension_paths: Optional[List[str]]) -> WebDriver:
+                 extension_paths: Optional[List[str]],
+                 webdriver_kwargs: Optional[dict]) -> WebDriver:
     """ Build a RemoteDriver connected to a Grid.
 
     Args:
@@ -294,6 +311,7 @@ def build_remote(browser: str,
         capabilities: The dict of capabilities to include.
         experimental_options: The list of experimental options to include.
         extension_paths: The list of extensions to add to the browser.
+        webdriver_kwargs: additional keyword arguments to pass.
 
     Returns:
         The instance of WebDriver once the connection is successful
@@ -305,5 +323,6 @@ def build_remote(browser: str,
     return webdriver.Remote(
         command_executor=remote_url,
         desired_capabilities=caps,
-        options=options
+        options=options,
+        **(webdriver_kwargs or {})
     )

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -8,6 +8,7 @@ def test_py_config_defaults(py_config):
     assert py_config.driver.version == 'latest'
     assert py_config.driver.capabilities == {}
     assert py_config.driver.experimental_options is None
+    assert py_config.driver.webdriver_kwargs == {}
 
     # logging settings
     assert py_config.logging.screenshots_on is True
@@ -33,6 +34,7 @@ def test_py_config(py_config):
     assert py_config.driver.version == 'latest'
     assert py_config.driver.capabilities == {}
     assert py_config.driver.experimental_options is None
+    assert py_config.driver.webdriver_kwargs == {}
 
     # logging settings
     assert py_config.logging.screenshots_on is True


### PR DESCRIPTION
Make it possible to e.g. customize the `geckodriver.log` path.