### PR TITLE
fixing Firefox webdriver instantiation, closes #235

### DIFF
--- a/pylenium/webdriver_factory.py
+++ b/pylenium/webdriver_factory.py
@@ -275,7 +275,7 @@ def build_firefox(
         return webdriver.Firefox(
             executable_path=local_path, options=options, capabilities=caps, **(webdriver_kwargs or {})
         )
-    return webdriver.Firefox(GeckoDriverManager(version=version).install(), options=options, **(webdriver_kwargs or {}))
+    return webdriver.Firefox(executable_path=GeckoDriverManager(version=version).install(), options=options, **(webdriver_kwargs or {}))
 
 
 def build_ie(

--- a/tests/unit/test_bugfixes.py
+++ b/tests/unit/test_bugfixes.py
@@ -1,0 +1,14 @@
+from unittest.mock import patch, MagicMock
+from pylenium import webdriver_factory
+
+
+def test_235_webdriver_factory(tmpdir):
+    file_to_use = tmpdir / "file"
+    file_to_use.write("test")
+    gecko_mock = MagicMock()
+    gecko_mock.install.return_value = file_to_use
+    with patch("pylenium.webdriver_factory.GeckoDriverManager", return_value=gecko_mock):
+        with patch("pylenium.webdriver_factory.webdriver.firefox.webdriver.Service"):
+            with patch("pylenium.webdriver_factory.webdriver.firefox.webdriver.RemoteWebDriver"):
+                webdriver_factory.build_firefox("latest", ["headless"], {}, [], [], "", {})
+                gecko_mock.install.assert_called_once()


### PR DESCRIPTION
Identify the Bug

https://github.com/ElSnoMan/pyleniumio/issues/235

Description of the Change
Fixing the bug introduced in `1.14.0` changing the way Firefox webdriver is instantiated to use gecko driver path directly as executable path, not as deprecated firefox_profile. 

Alternate Designs
N/A

Possible Drawbacks
N/A

Verification Process
TDD - first failing unit test has been written (heavily mocked), then the solution

Release Notes
reverting a way of Firefox webdriver instantiation to use a keyword argument instead of a positional one