### PR TITLE
Do not install another flake8 version in CI

### DIFF
--- a/.github/workflows/test-pylenium.yml
+++ b/.github/workflows/test-pylenium.yml
@@ -29,8 +29,6 @@ jobs:
           pip install poetry
           # install dependencies from pyproject.toml
           poetry install
-          # install flake8 for linting step
-          poetry add flake8
 
       - name: Lint with flake8
         run: |


### PR DESCRIPTION
flake8 is already specified as a dev-dependency in pyproject.toml, so adding it to the project will result in requiring two conflicting flake8 versions: The one specified in pyproject.toml and the latest one.