### PR TITLE
Added timeout to test-pylenium action

### DIFF
--- a/.github/workflows/test-pylenium.yml
+++ b/.github/workflows/test-pylenium.yml
@@ -44,7 +44,7 @@ jobs:
         uses: Xotabu4/selenoid-github-action@v2
         with:
           selenoid-start-arguments: |
-            --args "-timeout 300s"
+            --args "-timeout 250s"
 
       - name: Run UI Tests
         run: |

--- a/.github/workflows/test-pylenium.yml
+++ b/.github/workflows/test-pylenium.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Start Selenoid Server
         # https://github.com/marketplace/actions/start-selenoid-server?version=v2
         uses: Xotabu4/selenoid-github-action@v2
+        with:
+          selenoid-start-arguments: |
+            --args "-timeout 60s"
 
       - name: Run UI Tests
         run: |

--- a/.github/workflows/test-pylenium.yml
+++ b/.github/workflows/test-pylenium.yml
@@ -44,7 +44,7 @@ jobs:
         uses: Xotabu4/selenoid-github-action@v2
         with:
           selenoid-start-arguments: |
-            --args "-timeout 200s"
+            --args "-timeout 300s"
 
       - name: Run UI Tests
         run: |

--- a/.github/workflows/test-pylenium.yml
+++ b/.github/workflows/test-pylenium.yml
@@ -44,7 +44,7 @@ jobs:
         uses: Xotabu4/selenoid-github-action@v2
         with:
           selenoid-start-arguments: |
-            --args "-timeout 60s"
+            --args "-timeout 200s"
 
       - name: Run UI Tests
         run: |

--- a/.github/workflows/test-pylenium.yml
+++ b/.github/workflows/test-pylenium.yml
@@ -5,7 +5,7 @@ name: Build and Test Pylenium with Selenoid
 
 on:
   push:
-    branches: [patch-1]
+    branches: [main]
     paths-ignore:
       - "docs/**"
   pull_request:

--- a/.github/workflows/test-pylenium.yml
+++ b/.github/workflows/test-pylenium.yml
@@ -5,7 +5,7 @@ name: Build and Test Pylenium with Selenoid
 
 on:
   push:
-    branches: [main]
+    branches: [patch-1]
     paths-ignore:
       - "docs/**"
   pull_request:


### PR DESCRIPTION
1. The bug
UI tests sometimes fail during CI (fixes #307)

2. Description of the Change
I added a timeout argument after selenoid starts up on the runner.

```diff
name: Start Selenoid Server
# https://github.com/marketplace/actions/start-selenoid-server?version=v2
uses: Xotabu4/selenoid-github-action@v2
+    with:
+        selenoid-start-arguments: |
+        --args "-timeout 60s"
```

3. Verification
Tested on my own branch by changing the action trigger to ensure UI tests all passed. Then changed it back to its previous state once this was validated.

4. Release Notes
N/A


New to open source, open to any suggestions on how to improve this and/or future PRs!
