### PR TITLE
Add functions to measure how long an action

### DIFF
--- a/pylenium/performance.py
+++ b/pylenium/performance.py
@@ -113,9 +113,9 @@ class Performance:
         js = 'return performance.mark("{}");'.format(mark)
         self._wait().until(lambda driver: driver.execute_script(js), "PerformanceMark not generated yet")
 
-    def measure(self, start) -> float:
+    def measure(self, mark) -> float:
 
-        js = 'return performance.measure("Measure", "{}");'.format(start)
+        js = 'return performance.measure("Measure", "{}");'.format(mark)
         measured = self._wait().until(lambda driver: driver.execute_script(js), "PerformanceMeasure not generated yet")
         return PerformanceMeasure(**measured).duration
         

--- a/pylenium/performance.py
+++ b/pylenium/performance.py
@@ -109,21 +109,19 @@ class Performance:
         except TimeoutException:
             return None  # because there were no Resources captured for the current web page
 
-    def mark(self, name) -> str:
-        js = 'return window.performance.mark("{}")[0];'.format(name)
-        start_mark = self._wait().until(lambda driver: driver.execute_script(js), "PerformanceMark not generated yet")
-        print(start_mark)
-        return PerformanceMark(**start_mark).name
+    def mark(self, mark):
+        js = 'return performance.mark("{}");'.format(mark)
+        self._wait().until(lambda driver: driver.execute_script(js), "PerformanceMark not generated yet")
 
-    def measure(self, start_name) -> float:
-        end_name = self.mark("end")
-        js = 'return window.performance.measure("{}", "{}", "{}")[0];'.format("measure", start_name, end_name)
-        measures = self._wait().until(lambda driver: driver.execute_script(js),"PerformanceMeasure not generated yet")
-        print(measures)
+    def measure(self, start) -> float:
+
+        js = 'return performance.measure("Measure", "{}");'.format(start)
+        measured = self._wait().until(lambda driver: driver.execute_script(js), "PerformanceMeasure not generated yet")
+        return PerformanceMeasure(**measured).duration
         
 
 class PerformanceMeasure(BaseModel):
-    """The PerformanceNavigationTiming Representation.
+    """The PerformanceMeasure Representation.
 
     Metrics regarding the browser's document navigation events
 
@@ -131,7 +129,7 @@ class PerformanceMeasure(BaseModel):
         https://developer.mozilla.org/en-US/docs/Web/API/PerformanceMeasure
     """
 
-    detail: str = Field(alias="detail")
+    detail: None = Field(alias="detail")
     name: str = Field(alias="name")
     entry_type: str = Field(alias="entryType")
     start_time: float = Field(alias="startTime")
@@ -146,7 +144,7 @@ class PerformanceMark(BaseModel):
         https://developer.mozilla.org/en-US/docs/Web/API/PerformanceMark
     """
 
-    detail: str = Field(alias="detail")
+    detail: None = Field(alias="detail")
     name: str = Field(alias="name")
     entry_type: str = Field(alias="entryType")
     start_time: float = Field(alias="startTime")

--- a/pylenium/performance.py
+++ b/pylenium/performance.py
@@ -118,7 +118,6 @@ class Performance:
         js = 'return performance.measure("Measure", "{}");'.format(mark)
         measured = self._wait().until(lambda driver: driver.execute_script(js), "PerformanceMeasure not generated yet")
         return PerformanceMeasure(**measured).duration
-        
 
 class PerformanceMeasure(BaseModel):
     """The PerformanceMeasure Representation.

--- a/pylenium/performance.py
+++ b/pylenium/performance.py
@@ -110,14 +110,16 @@ class Performance:
             return None  # because there were no Resources captured for the current web page
 
     def mark(self, mark):
+        """Add a named mark) to the browser's performance timeline."""
         js = 'return performance.mark("{}");'.format(mark)
         self._wait().until(lambda driver: driver.execute_script(js), "PerformanceMark not generated yet")
 
     def measure(self, mark) -> float:
-
+        """Return duration in miliseconds"""
         js = 'return performance.measure("Measure", "{}");'.format(mark)
         measured = self._wait().until(lambda driver: driver.execute_script(js), "PerformanceMeasure not generated yet")
         return PerformanceMeasure(**measured).duration
+
 
 class PerformanceMeasure(BaseModel):
     """The PerformanceMeasure Representation.
@@ -134,6 +136,7 @@ class PerformanceMeasure(BaseModel):
     start_time: float = Field(alias="startTime")
     duration: float = Field(alias="duration")
 
+
 class PerformanceMark(BaseModel):
     """The PerformanceMark Representation.
 
@@ -148,6 +151,7 @@ class PerformanceMark(BaseModel):
     entry_type: str = Field(alias="entryType")
     start_time: float = Field(alias="startTime")
     duration: float = Field(alias="duration")
+
 
 class NavigationTiming(BaseModel):
     """The PerformanceNavigationTiming Representation.

--- a/pylenium/performance.py
+++ b/pylenium/performance.py
@@ -109,6 +109,48 @@ class Performance:
         except TimeoutException:
             return None  # because there were no Resources captured for the current web page
 
+    def mark(self, name) -> str:
+        js = 'return window.performance.mark("{}")[0];'.format(name)
+        start_mark = self._wait().until(lambda driver: driver.execute_script(js), "PerformanceMark not generated yet")
+        print(start_mark)
+        return PerformanceMark(**start_mark).name
+
+    def measure(self, start_name) -> float:
+        end_name = self.mark("end")
+        js = 'return window.performance.measure("{}", "{}", "{}")[0];'.format("measure", start_name, end_name)
+        measures = self._wait().until(lambda driver: driver.execute_script(js),"PerformanceMeasure not generated yet")
+        print(measures)
+        
+
+class PerformanceMeasure(BaseModel):
+    """The PerformanceNavigationTiming Representation.
+
+    Metrics regarding the browser's document navigation events
+
+    References:
+        https://developer.mozilla.org/en-US/docs/Web/API/PerformanceMeasure
+    """
+
+    detail: str = Field(alias="detail")
+    name: str = Field(alias="name")
+    entry_type: str = Field(alias="entryType")
+    start_time: float = Field(alias="startTime")
+    duration: float = Field(alias="duration")
+
+class PerformanceMark(BaseModel):
+    """The PerformanceMark Representation.
+
+    Metrics regarding the browser's document navigation events
+
+    References:
+        https://developer.mozilla.org/en-US/docs/Web/API/PerformanceMark
+    """
+
+    detail: str = Field(alias="detail")
+    name: str = Field(alias="name")
+    entry_type: str = Field(alias="entryType")
+    start_time: float = Field(alias="startTime")
+    duration: float = Field(alias="duration")
 
 class NavigationTiming(BaseModel):
     """The PerformanceNavigationTiming Representation.

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -27,12 +27,12 @@ class TestSauceDemo:
         sauce.getx("//a[@class='shopping_cart_link']").click()
         assert sauce.findx("//*[@class='cart_item']").should().have_length(6)
 
-    def test_add_to_cart_xpath(sauce: Pylenium):
+    def test_add_to_cart_xpath(self, sauce: Pylenium):
         """Add 6 different items to the cart. There should be 6 items in the cart."""
-        start_name = sauce.performance.mark("before")
+        sauce.performance.mark("Adding item in cart")
         for button in sauce.findx("//*[contains(@id, 'add-to-cart')]"):
             button.click()
         sauce.getx("//a[@class='shopping_cart_link']").click()
+        time_in_ms = sauce.performance.measure("Adding item in cart")
         assert sauce.findx("//*[@class='cart_item']").should().have_length(6)
-        time = sauce.performance.measure("measure", start_name)
-        assert time < 5, "Took longer than 5 seconds to add item to cart using xpath"
+        assert time_in_ms < 2000, "should be less 2000ms"

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -26,3 +26,13 @@ class TestSauceDemo:
             button.click()
         sauce.getx("//a[@class='shopping_cart_link']").click()
         assert sauce.findx("//*[@class='cart_item']").should().have_length(6)
+
+    def test_add_to_cart_xpath(sauce: Pylenium):
+        """Add 6 different items to the cart. There should be 6 items in the cart."""
+        start_name = sauce.performance.mark("before")
+        for button in sauce.findx("//*[contains(@id, 'add-to-cart')]"):
+            button.click()
+        sauce.getx("//a[@class='shopping_cart_link']").click()
+        assert sauce.findx("//*[@class='cart_item']").should().have_length(6)
+        time = sauce.performance.measure("measure", start_name)
+        assert time < 5, "Took longer than 5 seconds to add item to cart using xpath"

--- a/tests/test_flows.py
+++ b/tests/test_flows.py
@@ -27,8 +27,8 @@ class TestSauceDemo:
         sauce.getx("//a[@class='shopping_cart_link']").click()
         assert sauce.findx("//*[@class='cart_item']").should().have_length(6)
 
-    def test_add_to_cart_xpath(self, sauce: Pylenium):
-        """Add 6 different items to the cart. There should be 6 items in the cart."""
+    def test_add_to_cart_xpath_duration(self, sauce: Pylenium):
+        """Add 6 different items to the cart. There should be 6 items in the cart. Duration should be less than 2000ms"""
         sauce.performance.mark("Adding item in cart")
         for button in sauce.findx("//*[contains(@id, 'add-to-cart')]"):
             button.click()


### PR DESCRIPTION
[#260](https://github.com/ElSnoMan/pyleniumio/issues/260)
Limitation as of now:

The mark() and measure() only can be used in the same window/page. If user changes the page where mark's entry was set, it will fail when we call measure(). i.e Failed to execute 'measure' on 'Performance': The mark '<mark>' does not exist.